### PR TITLE
fix: FAQ mobile styling

### DIFF
--- a/src/components/FAQ/Container.jsx
+++ b/src/components/FAQ/Container.jsx
@@ -7,22 +7,6 @@ const Container = styled.div`
   position: relative;
   height: 1080px;
 
-  @media only screen and (max-width: 1300px) {
-    height 990px;
-  }
-
-  @media only screen and (max-width: 1000px) {
-    height 900px;
-  }
-
-  @media only screen and (max-width: 900px) {
-    height: 1430px;
-  }
-
-  @media only screen and (max-width: 400px) {
-    height: 1520px;
-  }
-
   .QuestionBox {
     border: 1px solid ${styleVars.faqBlue2};
     padding: 10px 10px;
@@ -90,6 +74,26 @@ const Container = styled.div`
         opacity: 90%;
       }
     }
+  }
+  
+  @media only screen and (max-width: 1300px) {
+    height 990px;
+  }
+
+  @media only screen and (max-width: 1000px) {
+    height 900px;
+  }
+
+  @media only screen and (max-width: 900px) {
+    height: 1430px;
+  }
+
+  @media only screen and (max-width: 425px) {
+    height: 1710px;
+  }
+
+  @media only screen and (max-width: 325px) {
+    height: 1980px;
   }
 `
 

--- a/src/components/FAQ/Container.jsx
+++ b/src/components/FAQ/Container.jsx
@@ -16,8 +16,10 @@ const Container = styled.div`
   }
 
   @media only screen and (max-width: 900px) {
-    padding-top: 110px;
-    padding-bottom: 90px;
+    height: 1430px;
+  }
+
+  @media only screen and (max-width: 400px) {
     height: 1520px;
   }
 

--- a/src/components/FAQ/Window.jsx
+++ b/src/components/FAQ/Window.jsx
@@ -101,6 +101,8 @@ export const Window = styled.div`
       max-height: none;
       padding-top: 80px;
       padding-bottom: 100px;
+      padding-left: 40px;
+      padding-right: 40px;
     }
     
     .grid {

--- a/src/components/FAQ/Window.jsx
+++ b/src/components/FAQ/Window.jsx
@@ -83,9 +83,9 @@ export const Window = styled.div`
     }
   }
 
-  @media only screen and (max-width: 900px) {
+  @media only screen and (max-width: 1000px) {
     background-image: none;
-    background-color: ${styleVars.hackWhite}aa;
+    background-color: ${styleVars.hackWhite};
 
     border-radius: 32px;
     max-height: none;
@@ -107,6 +107,7 @@ export const Window = styled.div`
       position: initial;
       display: flex;
       height: initial;
+      width: 100%;
       flex-flow: column wrap;
       align-content: center;
       max-width: 500px;
@@ -121,12 +122,6 @@ export const Window = styled.div`
       margin: 20px;
       box-sizing: border-box;
     }
-  }
-
-  @media only screen and (max-width: 840px) {
-    width: 100%;
-    max-width: 100%;
-    border-radius: 0;
   }
 `
 export default Window


### PR DESCRIPTION
### Tickets:

- HCK-

### List of changes:

- Changed some CSS for the FAQ for low-width screens so it looks like the design
- Previously background looked transparent on mobile and content would clip past container on certain widths

### Type of change:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] New release
- [ ] Requires a documentation update

### How did you do this?

### Why are you choosing this approach?

### Questions for code reviewers?

### PR Checklist:

- [X] Merged `develop` branch (before testing)
- [ ] Ran `yarn format` to format code
- [ ] Listed change(s) in the Changelog
- [X] Tested all links in project relevant browsers
- [X] Tested all links on different screen sizes
- [ ] Referenced all useful info (issues, tasks, etc)
