### PR TITLE
Prevent >100% width on mobile

### DIFF
--- a/src/components/Schedule/Container.jsx
+++ b/src/components/Schedule/Container.jsx
@@ -62,7 +62,7 @@ export const Container = styled.section`
       display: flex;
       align-items: center;
 
-      @media all and (max-width: 600px) {
+      @media all and (max-width: ${styleVars.smUp}) {
         padding: 24px 0px 24px 16px;
       }
 
@@ -86,7 +86,7 @@ export const Container = styled.section`
       text-align: left;
       display: flex;
       align-items: center;
-      @media all and (max-width: 600px) {
+      @media all and (max-width: ${styleVars.smUp}) {
         padding: 24px 0px 24px 16px;
       }
       .overview {
@@ -136,7 +136,7 @@ export const Container = styled.section`
       margin-top: auto;
       margin-bottom: auto;
 
-      @media all and (max-width: 600px) {
+      @media all and (max-width: ${styleVars.smUp}) {
         padding: 24px 0px 24px 16px;
       }
     }

--- a/src/components/Schedule/Container.jsx
+++ b/src/components/Schedule/Container.jsx
@@ -62,6 +62,10 @@ export const Container = styled.section`
       display: flex;
       align-items: center;
 
+      @media all and (max-width: 600px) {
+        padding: 24px 0px 24px 16px;
+      }
+
       .to {
         font-size: 0.85em;
       }
@@ -82,7 +86,9 @@ export const Container = styled.section`
       text-align: left;
       display: flex;
       align-items: center;
-
+      @media all and (max-width: 600px) {
+        padding: 24px 0px 24px 16px;
+      }
       .overview {
         flex: 1;
 
@@ -129,6 +135,10 @@ export const Container = styled.section`
       margin-right: auto;
       margin-top: auto;
       margin-bottom: auto;
+
+      @media all and (max-width: 600px) {
+        padding: 24px 0px 24px 16px;
+      }
     }
 
     .icon > *:before {


### PR DESCRIPTION
### Tickets:
UPDATED MOBILE SCREEN:
<img width="326" alt="Screen Shot 2022-01-21 at 1 36 41 PM" src="https://user-images.githubusercontent.com/33589920/150581887-0db204ac-0830-4ff2-806d-1e87799928a3.png">

### List of changes:


### Type of change:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] New release
- [ ] Requires a documentation update

### How did you do this?

### Why are you choosing this approach?

### Questions for code reviewers?

### PR Checklist:

- [ ] Merged `develop` branch (before testing)
- [ ] Ran `yarn format` to format code
- [ ] Listed change(s) in the Changelog
- [ ] Tested all links in project relevant browsers
- [ ] Tested all links on different screen sizes
- [ ] Referenced all useful info (issues, tasks, etc)
